### PR TITLE
[FIX]ログイン、マイグレーションの並び

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
-class RecruitLoginController extends Controller
+class LoginController extends Controller
 {
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,8 +15,8 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name');
-            $table->string('email')->unique();
+            $table->string('name')->comment('ユーザー名');
+            $table->string('email')->unique()->comment('メールアドレス');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/2019_12_29_054319_add_column_to_users_table.php
+++ b/database/migrations/2019_12_29_054319_add_column_to_users_table.php
@@ -14,7 +14,7 @@ class AddColumnToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('img_name')->nullable()->default('');
+            $table->string('img_name')->nullable()->default('')->after('password');
         });
     }
 

--- a/database/migrations/2020_01_12_111653_create_posts_table.php
+++ b/database/migrations/2020_01_12_111653_create_posts_table.php
@@ -15,9 +15,9 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
+            $table->integer('user_id');
             $table->string('place');
             $table->string('caption');
-            $table->integer('user_id');
             $table->integer('cost')->nullable();
             $table->timestamps();
         });

--- a/database/migrations/2020_01_20_230426_add_to_posts_sport.php
+++ b/database/migrations/2020_01_20_230426_add_to_posts_sport.php
@@ -14,7 +14,7 @@ class AddToPostsSport extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->string('sport');
+            $table->string('sport')->after('cost');
         });
     }
 

--- a/database/migrations/2020_01_29_214042_add_introduce_to_users_table.php
+++ b/database/migrations/2020_01_29_214042_add_introduce_to_users_table.php
@@ -14,7 +14,7 @@ class AddIntroduceToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('introduce')->nullable()->default('よろしくお願いします');  
+            $table->string('introduce')->nullable()->default('よろしくお願いします')->after('password');  
         });
     }
 

--- a/database/migrations/2020_02_03_163858_add_to_posts_comment.php
+++ b/database/migrations/2020_02_03_163858_add_to_posts_comment.php
@@ -14,7 +14,7 @@ class AddToPostsComment extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->string('comment');
+            $table->string('comment')->nullable();
         });
     }
 


### PR DESCRIPTION
ひとまずAuthをなおしたやつのプルリク投げました。
ついでにですが、DBのマイグレーションの並びを変えさせてもらいました。
DBのテーブル設計は、慣例でCreatedとModifiedをカラムの最後に持っていきます。
あとuser_idなどの外部キーはプライマリーキーの後に持ってくる事が多いですね。ぱっと見でリレーション先のテーブルが分かりやすいので。